### PR TITLE
renaming EMBREE to embree in CMakeLitst.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(PyCinema)
 
 find_package(ParaView REQUIRED)
 
-find_package(EMBREE REQUIRED)
+find_package(embree REQUIRED)
 find_package(OpenMP)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)


### PR DESCRIPTION
find_package is case sensitive, and embree should have no caps